### PR TITLE
Set next meeting date to May 19 2026

### DIFF
--- a/data/meetup.json
+++ b/data/meetup.json
@@ -1,5 +1,5 @@
 {
-  "date": "2026-04-28",
-  "eventUrl": "https://www.meetup.com/cville-tech/",
+  "date": "2026-05-19",
+  "eventUrl": "https://www.meetup.com/cville-tech/events/314635275",
   "fallbackUrl": "https://www.meetup.com/cville-tech/"
 }


### PR DESCRIPTION
Updates `data/meetup.json` to set the next meeting date to May 19, 2026, linked to the specific Meetup event page.

https://claude.ai/code/session_017mLao3Hc5Zftv6iDf4UMue